### PR TITLE
Small typo and sentence construction fixes

### DIFF
--- a/source/administration/high_availability.rst
+++ b/source/administration/high_availability.rst
@@ -381,13 +381,13 @@ data it was missing from the now-gone BE1, and you can begin the process of
 bringing Private Chef back online.
 
 Running a fast network between the BE1 and BE2 hosts, and keeping it full
-throttle for drdb transfers, will go a long way to mitigating the damage done
+throttle for drbd transfers, will go a long way to mitigating the damage done
 in the event of a loss of the Primary from and unsynced cluster.
 
 Scenario 5
 ~~~~~~~~~~
 
-Sometimes drdb hedges its bets, and puts both nodes in a pair into Secondary
+Sometimes drbd hedges its bets, and puts both nodes in a pair into Secondary
 mode.  When this happens, you can look at the contents of :file:`/proc/drbd` on
 both hosts and see if either of them is showing out of sync.  If they are both
 “oos:0”, just pick one and promote it to Primary with the above

--- a/source/engagement/onsite.rst
+++ b/source/engagement/onsite.rst
@@ -22,7 +22,7 @@ Installation of Private Chef
 ----------------------------
 
 Once the consultants have ensured the prerequisites are met, the installation
-of Private Chef will begin. The servers will be connected to the Hosted Chef,
+of Private Chef will begin. The servers will be connected to the Hosted Chef service,
 in order to build and configure the services. 
 
 Configuration of HA Services

--- a/source/engagement/preinstall.rst
+++ b/source/engagement/preinstall.rst
@@ -10,7 +10,7 @@ Complete the pre-installation questionaire
 The Pre-Installation Questionnaire provides Opscode with information that often
 streamlines the installation process, and ensures a smooth on-site delivery.
 The questions are delivered as messages within your project portal. To access
-the them:
+the messages:
 
 1. Log in to the Client Portal
 2. Click the “Message” tab

--- a/source/support.rst
+++ b/source/support.rst
@@ -6,7 +6,7 @@ Support
   pair: support; contact information
 
 The Opscode Support Engineering team is an interface between Customer’s
-Designated Contact Personnel and Opscode for support of services provided by
+Designated Contact Personnel and Opscode for the support of services provided by
 Opscode.  This arrangement provides Customer with access to a direct point of
 contact for reporting incidents, receiving updates and escalation.  
 
@@ -28,13 +28,13 @@ Customer will communicate incidents to Opscode in one of the following manners:
 
 *	Use the web interface http://help.opscode.com/ to directly open a trouble ticket at that site, or 
 
-*	Directing an email to Private Chef Support (support@opscode.com), with the sending email address being one of those associated with Customer's organization on Private Chef. 
+*	Direct an email to Private Chef Support (support@opscode.com), with the sending email address being one of those associated with Customer's organization on Private Chef. 
 
 *	Please note that the Opscode Support Phone Number (206-508-4799) is for contact only.  
 
   *	Depending upon the specifics of the issue, it is highly unlikely that real-time analysis and resolution can occur over the phone.  
 
-  *	The phone call can initiate support response, but the following will be required from the customer prior upon engaging support - to ensure meaningful action can be effectively and efficiently undertaken for problem resolution.
+  *	The phone call can initiate support response, but the following will be required from the customer prior to engaging support. This will ensure meaningful action can be effectively and efficiently undertaken for problem resolution.
 
   *	Customer documentation of the issue, as experienced from their perspective and particular use case.  
 
@@ -185,7 +185,7 @@ Issue causes little impact to functionality or Private Chef use. A reasonable ci
 
 :Support Response Targets: - Address as time permits, best effort.
 :Customer Response Targets: - Customer response within 2 service days following
-                              service hour based receipt of support 
+                              service hour based receipt of report 
                             - Subsequent updates as warranted, or as agreed.
 
 .. note::


### PR DESCRIPTION
Are we going to persist with the "Customer" and "Customer's" not being preceded by "The" or "the" all over but especially heavy in the Support section?

I held off on those given that it is sort of a legal doc. We should minimize that usage n order to be a good manual, where we can, I think.
