### PR TITLE
Doc tuneups: ssh port forwards, fail typo, big warn about DRBD create-md

### DIFF
--- a/source/administration.rst
+++ b/source/administration.rst
@@ -14,6 +14,7 @@ This section will guide you through the most common administrative tasks associa
 -  :doc:`AD/LDAP </administration/ad_ldap>`: Active Directory/LDAP Auth Configuration.
 -  :doc:`Access </administration/access>`: Alternative methods to access subsystems running in the Private Chef Backends.
 -  :doc:`Access Control </administration/access_control>`: Manage access rights with ACLs.
+-  :doc:`Ports </administration/ports>`: Full List of Ports
 -  :doc:`Configuration </administration/upgrading>`: All control attributes for /etc/opscode/private-chef.rb in one place.
 
 .. toctree::
@@ -28,5 +29,6 @@ This section will guide you through the most common administrative tasks associa
    administration/ad_ldap
    administration/access
    administration/access_control
+   administration/ports
    administration/configuration
 

--- a/source/administration.rst
+++ b/source/administration.rst
@@ -22,4 +22,5 @@ This section will guide you through the most common administrative tasks associa
    administration/nagios
    administration/upgrading
    administration/ad_ldap
+   administration/access
 

--- a/source/administration.rst
+++ b/source/administration.rst
@@ -8,12 +8,16 @@ This section will guide you through the most common administrative tasks associa
 -  :doc:`Logs </administration/logs>`: Information on what is logged by Private Chef, and how to use them for troubleshooting.
 -  :doc:`User Management </administration/user_management>`: An overview of User Management.
 -  :doc:`High Availability </administration/high_availability>`: An in-depth tour of the High Availability features of Private Chef.
+-  :doc:`OrgMapper </administration/org_mapper>`: Extremely powerful (and dangerous) tool for manipulating Private Chef data.
 -  :doc:`Monitoring </administration/nagios>`: Monitoring tools (Nagios) included with Private Chef.
 -  :doc:`Upgrading </administration/upgrading>`: Step-by-step guide to upgrading Private Chef.
+-  :doc:`AD/LDAP </administration/ad_ldap>`: Active Directory/LDAP Auth Configuration.
+-  :doc:`Access </administration/access>`: Alternative methods to access subsystems running in the Private Chef Backends.
+-  :doc:`Access Control </administration/access_control>`: Manage access rights with ACLs.
+-  :doc:`Configuration </administration/upgrading>`: All control attributes for /etc/opscode/private-chef.rb in one place.
 
 .. toctree::
   
-   administration/configuration
    administration/private_chef_ctl
    administration/logs
    administration/user_management
@@ -23,4 +27,6 @@ This section will guide you through the most common administrative tasks associa
    administration/upgrading
    administration/ad_ldap
    administration/access
+   administration/access_control
+   administration/configuration
 

--- a/source/administration/access.rst
+++ b/source/administration/access.rst
@@ -1,0 +1,24 @@
+.. index::
+  single: access
+
+=============================
+Access
+=============================
+
+.. index::
+  pair: access; ssh_nagios
+
+SSH Access to Nagios
+--------------------
+
+In order to access Nagios on the primary/standalone backend with only a SSH connection, make your SSH connection this way
+
+.. code-block:: bash
+
+  $ ssh -L9671:localhost:9671 USERNAME@PRIVATE_CHEF_BACKEND_FQDN
+
+And then in a browser location line enter the URL: http://localhost:9671/nagios
+
+.. note::
+
+   The default username/password for Nagios in a Private Chef installation can be found at :ref:`Nagios Auth Settings <configuration-nagios-auth>`

--- a/source/administration/access.rst
+++ b/source/administration/access.rst
@@ -22,3 +22,14 @@ And then in a browser location line enter the URL: http://localhost:9671/nagios
 .. note::
 
    The default username/password for Nagios in a Private Chef installation can be found at :ref:`Nagios Auth Settings <configuration-nagios-auth>`
+
+SSH Access to CouchDB/Futon
+---------------------------
+
+In order to access CouchDB or Futon on the primary/standalone backend with only a SSH connection, make your SSH connection this way
+
+.. code-block:: bash
+
+  $ ssh -L5984:localhost:5984 USERNAME@PRIVATE_CHEF_BACKEND_FQDN
+
+And then in a browser location line enter the URL: http://localhost:5984/_utils

--- a/source/administration/access_control.rst
+++ b/source/administration/access_control.rst
@@ -1,0 +1,112 @@
+.. index::
+  single: access
+
+=============================
+Access Control
+=============================
+
+.. index::
+  pair: access control; users cannot update org validator
+
+Create a Group Having No Ability to Update the Org Validator
+------------------------------------------------------------
+
+Requirements: You will need the UNSUPPORTED knife-acl plugin and a little time.
+
+1) We are going to create a new group in the Private Chef webUI named anything that makes sense in your org. The one I created was named **no-update-validator**
+
+2) Next, we will install the knife-acl knife plugin, preferrably in a new rbenv/rvm gemset, to avoid possibly trashing a working ruby gems setup.
+
+  .. code-block:: bash
+
+	$ gem install knife-acl
+
+3) Then, using knife-acl, we can manage the permissions on the Nodes container for a given org in our Private Chef installation.
+
+  For example, with a .chef/knife.rb configured properly and pointing at the organization where I just created the "no-update-validator" group, I can execute the following command and see the permissions on the top-level Nodes container for this org. Objects inherit the permissions of their container, if not manually assigned any others after creation.
+
+  .. code-block:: bash
+
+    $ knife acl show containers nodes  
+
+  ::
+
+    create: 
+      actors:  []
+      groups: 
+	  admins
+	  users
+	  clients
+	  no-update-validator
+    delete: 
+      actors:  ["pivotal"]
+      groups: 
+	  admins
+	  users
+    grant:  
+      actors:  ["pivotal"]
+      groups:  ["admins"]
+    read:   
+      actors:  []
+      groups: 
+	  admins
+	  users
+	  clients
+	  no-update-validator
+    update: 
+      actors:  ["pivotal"]
+      groups: 
+	  admins
+	  users  
+
+  .. code-block:: bash
+
+    $ knife acl add containers nodes delete group no-update-validator
+
+  .. code-block:: bash
+
+    $ knife acl add containers nodes update group no-update-validator
+
+  .. code-block:: bash
+
+    $ knife acl show containers nodes  
+
+  ::
+
+    create: 
+      actors:  []
+      groups: 
+	  admins
+	  users
+	  clients
+	  no-update-validator
+    delete: 
+      actors:  ["pivotal"]
+      groups: 
+	  admins
+	  users
+	  no-update-validator
+    grant:  
+      actors:  ["pivotal"]
+      groups:  ["admins"]
+    read:   
+      actors:  []
+      groups: 
+	  admins
+	  users
+	  clients
+	  no-update-validator
+    update: 
+      actors:  ["pivotal"]
+      groups: 
+	  admins
+	  users
+	  no-update-validator
+
+  And we see that the no-update-validator group now has update and delete permissions on the nodes container.
+
+4) Finally, continue on with the other permissions for the Nodes container, and the other permissions for the other containers needed, like Environments, Users, and so on.
+
+.. note::
+	  
+	  The permissions above can be understood more completely by referring to http://wiki.opscode.com/display/chef/Hosted+Chef+Authorization

--- a/source/administration/configuration.rst
+++ b/source/administration/configuration.rst
@@ -1890,6 +1890,8 @@ nagios['admin_pager']
 .. index::
   triple: configuration; nagios; admin_password
 
+.. _configuration-nagios-auth:
+
 nagios['admin_password']
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/administration/logs.rst
+++ b/source/administration/logs.rst
@@ -49,9 +49,9 @@ To view a specific services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl SERVICENAME tail
+  $ private-chef-ctl tail SERVICENAME
 
-Where ``SERVICENAME`` should be replaced with name of the service whose logs you want to view.
+Where ``SERVICENAME`` should be replaced with the name of the service whose logs you want to view.
 
 Services
 --------
@@ -68,7 +68,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl couchdb tail
+  $ private-chef-ctl tail couchdb
 
 .. index::
   pair: logs; fcgiwrap
@@ -82,7 +82,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl fcgiwrap tail
+  $ private-chef-ctl tail fcgiwrap
 
 .. index::
   pair: logs; nagios
@@ -97,7 +97,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl nagios tail
+  $ private-chef-ctl tail nagios
 
 .. index::
   pair: logs; nginx
@@ -136,7 +136,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl nginx tail
+  $ private-chef-ctl tail nginx
 
 Reading Access Logs
 ###################
@@ -187,7 +187,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl nrpe tail
+  $ private-chef-ctl tail nrpe
 
 .. index::
   pair: logs; opscode-account
@@ -201,7 +201,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-account tail
+  $ private-chef-ctl tail opscode-account
 
 .. index::
   pair: logs; opscode-authz
@@ -223,7 +223,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-authz tail
+  $ private-chef-ctl tail opscode-authz
 
 .. index::
   pair: logs; opscode-certificate
@@ -237,7 +237,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-certificate tail
+  $ private-chef-ctl tail opscode-certificate
 
 .. index::
   pair: logs; opscode-chef
@@ -251,7 +251,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-chef tail
+  $ private-chef-ctl tail opscode-chef
 
 .. index::
   pair: logs; opscode-erchef
@@ -268,7 +268,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-erchef tail
+  $ private-chef-ctl tail opscode-erchef
 
 .. index::
   pair: logs; opscode-expander
@@ -282,7 +282,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-expander tail
+  $ private-chef-ctl tail opscode-expander
 
 .. index::
   pair: logs; opscode-expander-reindexer
@@ -296,7 +296,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-expander-reindexer tail
+  $ private-chef-ctl tail opscode-expander-reindexer
 
 .. index::
   pair: logs; opscode-org-creator
@@ -310,7 +310,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-org-creator tail
+  $ private-chef-ctl tail opscode-org-creator
 
 .. index::
   pair: logs; opscode-solr
@@ -324,7 +324,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-solr tail
+  $ private-chef-ctl tail opscode-solr
 
 .. index::
   pair: logs; opscode-webui
@@ -338,7 +338,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-webui tail
+  $ private-chef-ctl tail opscode-webui
 
 .. index::
   pair: logs; phpfpm
@@ -352,7 +352,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl phpfpm tail
+  $ private-chef-ctl tail phpfpm
 
 .. index::
   pair: logs; postgresql
@@ -366,7 +366,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl postgresql tail
+  $ private-chef-ctl tail postgresql
 
 .. index::
   pair: logs; rabbitmq
@@ -380,7 +380,7 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl rabbitmq tail
+  $ private-chef-ctl tail rabbitmq
 
 .. index::
   pair: logs; redis
@@ -394,6 +394,6 @@ To follow this services logs:
 
 .. code-block:: bash
 
-  $ private-chef-ctl redis tail
+  $ private-chef-ctl tail redis
 
 

--- a/source/administration/ports.rst
+++ b/source/administration/ports.rst
@@ -1,0 +1,40 @@
+Private Chef Ports
+~~~~~~~~~~~~~~~~~~~
+
+The ports are all tcp protocol unless otherwise noted.
+
+====================   =======
+ Service                Port 
+~~~~~~~~~~~~~~~~~~~~
+
+ Backends
+====================   =======
+ drbd                   7788
+ keepalived (raw)       112
+ solr                   8983
+ rabbitmq               5672
+ couchdb                5984
+ postgresql             5432
+ redis                  6379
+ bookshelf              4321
+ opscode-chef           9460
+ opscode-erchef         8000
+ opscode-authz          9463
+ opscode-certificate    5140
+ opscode-org-creator    4369
+ opscode-account        9465
+ opscode-reporting      10010
+ estatsd (udp)          9466
+ nagios                 9671
+ nrpe                   9672
+====================   =======
+
+
+
+====================   =======
+ Frontends              Port 
+====================   =======
+ opscode-webui          9462
+ nginx ssl              443
+ nginx non-ssl          80 
+====================   =======

--- a/source/administration/private_chef_ctl.rst
+++ b/source/administration/private_chef_ctl.rst
@@ -1,4 +1,4 @@
-.. index::
+.. index:: opscode-solr
   single: private-chef-ctl
 
 =============================
@@ -9,6 +9,19 @@ Private Chef has a command line utility, :command:`private-chef-ctl`, which is
 used to perform the majority of the administrative activities associated with
 Private Chef, such as managing services, configuring the servers, and watching
 logs.
+
+private-chef-ctl as of v1.4.0 has reversed the order of arguments from NOUN VERB to VERB NOUN.
+This matches the behavior of the chef-server-ctl command in the Chef 11 Server.
+
+The following examples illustrate the old argument order, then the new
+
+.. code-block:: bash
+
+  $ private-chef-ctl opscode-solr tail
+
+.. code-block:: bash
+
+  $ private-chef-ctl tail opscode-solr
 
 :command:`private-chef-ctl` takes commands as arguments, and each
 command is documented below. To execute a command:
@@ -123,7 +136,7 @@ This command can also be run for an individual service, rather than every servic
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-solr status
+  $ private-chef-ctl status opscode-solr
 
 Any service listed in :command:`private-chef-ctl service-list` can replace `opscode-solr` in the above.
 
@@ -235,7 +248,7 @@ You can also start only a single service, rather than all services:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-solr start
+  $ private-chef-ctl start opscode-solr
 
 .. note::
 
@@ -259,7 +272,7 @@ You can also stop only a single service:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-solr stop
+  $ private-chef-ctl stop opscode-solr
 
 .. index::
   pair: private-chef-ctl; restart
@@ -273,7 +286,7 @@ You can also restart only a single service:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-solr restart
+  $ private-chef-ctl restart opscode-solr
 
 .. index::
   pair: private-chef-ctl; once
@@ -294,7 +307,7 @@ You can also tell only a specific service to run once:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-solr once
+  $ private-chef-ctl once opscode-solr
 
 .. index::
   pair: private-chef-ctl; hup
@@ -308,7 +321,7 @@ You can also hup only a specific service:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-solr hup
+  $ private-chef-ctl hup opscode-solr
 
 .. index::
   pair: private-chef-ctl; term
@@ -322,7 +335,7 @@ You can also send term to only a specific service:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-solr term
+  $ private-chef-ctl term opscode-solr
 
 .. index::
   pair: private-chef-ctl; int
@@ -336,7 +349,7 @@ You can also send int to only a specific service:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-solr int
+  $ private-chef-ctl int opscode-solr
 
 .. index::
   pair: private-chef-ctl; kill
@@ -350,7 +363,7 @@ You can also send a kill to only a specific service:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-solr kill
+  $ private-chef-ctl kill opscode-solr
 
 .. index::
   pair: private-chef-ctl; tail
@@ -364,7 +377,7 @@ You can also watch the logs of a specific service:
 
 .. code-block:: bash
 
-  $ private-chef-ctl opscode-solr tail
+  $ private-chef-ctl tail opscode-solr
 
 
 User Administration Commands

--- a/source/conf.py
+++ b/source/conf.py
@@ -106,7 +106,7 @@ html_theme = 'sphinxdoc'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = "Private Chef Guide v1.0.1-1"
+html_title = "Private Chef Guide v1.4.0"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None

--- a/source/installation/ha.rst
+++ b/source/installation/ha.rst
@@ -268,7 +268,7 @@ balanced VIP.
 Completed private-chef.rb example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A completed private-chef.rb configuration file for a four server tiered
+A completed private-chef.rb configuration file for a five server HA
 private chef cluster, consisting of:
 
 ================ =========== ================== ====
@@ -291,7 +291,7 @@ Looks like this:
 
   topology "ha"
 
-  server "be1.example.com"
+  server "be1.example.com",
    :ipaddress => "192.168.4.1",
    :role => "backend",
    :bootstrap => true,
@@ -654,7 +654,7 @@ installation. When it is complete, you will see:
 Success!
 --------
 
-Congratulations, you have installed Private Chef in a tiered
+Congratulations, you have installed Private Chef in an HA
 configuration. You should now continue with the :doc:`User Management </administration/user_management>` section
 of this guide.
 

--- a/source/installation/ha.rst
+++ b/source/installation/ha.rst
@@ -354,7 +354,9 @@ Install the Private Chef package on both of the back-end servers.
 Install DRBD on both of the back-end servers
 --------------------------------------------
 
-Both of the back-end servers must have DRBD installed.
+.. warning::
+
+  Both of the back-end servers must have DRBD metadata added to their local disks in order for failover to work properly. The directions for this step will follow for both systems.
 
 *Install DRBD on Red Hat and CentOS 6*
 
@@ -437,6 +439,10 @@ set up DRBD.
 
   $ drbdadm create-md pc0
   $ drbdadm up pc0
+
+.. warning::
+
+  drbdadm create-md pc0 must be done on both nodes of an ha backend cluster. Please confirm this step has happened on both nodes before continuing.
 
 Make the bootstrap server primary for DRBD
 ------------------------------------------

--- a/source/installation/ha.rst
+++ b/source/installation/ha.rst
@@ -50,10 +50,8 @@ block device, to ensure that data written to disk on one back-end server
 is efficiently replicated to another. For optimal performance and
 reliability, we recommend that:
 
--  Your back-end servers have a 100M+ ethernet interface cross-connected
-   to the other, for the cluster keepalive signal.
 -  Your back-end servers have a 10G+ ethernet interface cross-connected
-   to the other, for DRBD data replication.
+   to the other, for DRBD data replication and the cluster keepalived signal.
 
 This is in addition to the standard network interfaces on your systems.
 While DRBD replication can function on systems without these additional
@@ -66,7 +64,7 @@ Back-End Virtual IP Address
 The back-end servers will share a Virtual IP Address (which we will
 refer to later as the ``back-end VIP``), which needs to be accessible
 from the front-end servers. This VIP will be created and managed by Private
-Chef but will need be added to DNS to access the cluster.
+Chef but will need to be added to DNS to access the cluster.
 
 Back-End disk configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/installation/prereqs.rst
+++ b/source/installation/prereqs.rst
@@ -18,11 +18,10 @@ Choosing a Supported Operating Systems
 
 Private Chef is supported on the following operating systems:
 
--  Red Hat Enterprise Linux 6
--  CentOS 6
--  Ubuntu 10.04
+-  Red Hat Enterprise Linux 5 and 6 and clones (CentOS, etc)
+-  Ubuntu 10.04 and 11.04
 
-Private Chef requires an x86_64 compatible systems architecture.
+Private Chef requires a 64-bit x86_64 compatible systems architecture.
 
 Configuring the Operating System
 --------------------------------

--- a/source/installation/prereqs.rst
+++ b/source/installation/prereqs.rst
@@ -127,19 +127,19 @@ If you see a response like the above, you have the qpid server installed. To dis
   $ service qpidd stop
   $ chkconfig --del qpidd
 
+
 Required Users
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 If your environment has restrictions on the creation of local user and group
 accounts (via the ``adduser`` command), you will need to ensure that the
 following users exist:
 
-========            =====     ====
-Username            Shell     Home
-========            =====     ====
-opscode             /bin/bash /opt/opscode/embedded
-opscode-pgsql       /bin/bash /var/opt/opscode/postgresql
-opscode-nagios      /bin/bash /var/opt/opscode/nagios
-opscode-nagios-cmd  /bin/bash /var/opt/opscode/nagios
-========            =====     ====
-
+====================  ===========  =============================
+Username              Shell        Home
+====================  ===========  =============================
+opscode               /bin/bash    /opt/opscode/embedded
+opscode-pgsql         /bin/bash    /var/opt/opscode/postgresql
+opscode-nagios        /bin/bash    /var/opt/opscode/nagios
+opscode-nagios-cmd    /bin/bash    /var/opt/opscode/nagios
+====================  ===========  =============================


### PR DESCRIPTION
1. Specifically mention tunneling port 9671 for viewing Nagios pages with only SSH access to backends.
2. HA installation doc was specifying "tiered" instead of "ha". Sample private-chef.rb had fail bug comma typo.
3. Add words about connecting to the CouchDB installation's Futon web interface with ssh port forwards.
4. WARN about drbdadm create-md pc0 needing to be done on both nodes in an HA installation. People still miss it :(
5. Rearrange Admnistration and add access_control link
6. Add access_control example
7. OPC Doesn't support more than two network interfaces at this time
